### PR TITLE
Fix modbus CRC and shorter resp len (FW after 2020), fix serial receive, fix maximum 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ Remote utility programs for Kunkin KP184 electronic load for Linux/Cygwin.
 **kp184cmd** interactive command line utility  
 **battery**  battery discharge utility  
 **kp184.py** battery capacity calculator and graph plotter based on discharge utility CSV data  
+
+NOTE: KP184 communication CRC is different from 2020 firmware and above. You should check and try -o program option.

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Remote utility programs for Kunkin KP184 electronic load for Linux/Cygwin.
 **battery**  battery discharge utility  
 **kp184.py** battery capacity calculator and graph plotter based on discharge utility CSV data  
 
-NOTE: KP184 communication CRC is different from 2020 firmware and above. You should check and try -o program option.
+NOTE: KP184 communication CRC is different from 2020 firmware and above. You should check and try -O program option.

--- a/battery.cpp
+++ b/battery.cpp
@@ -167,7 +167,8 @@ void usage(const char prog[])
 {
   printf("usage: %s <-t tty|-s host[:port]> <-l load> <-v Volt> [-B conf] [-a addr]"
          " [-V Volt] [-c Amp] [-C Amp] [-i interval] [-N samples] [-n samples]"
-         " [-f path] [-o] [-q]\n", prog);
+         " [-f path] [-o]  [-O] [-q]\n", prog);
+  printf(" -O: older KP184 firmware before 2020\n");
   printf(" -t: communicate via TTY port\n");
   printf(" -s: communicate via socket\n");
   printf(" -B: serial configuration string [%s]\n", defconf_serial);
@@ -208,10 +209,13 @@ int main(int argc, char *argv[])
   static struct sigaction sigact;
   siginfo_t sinfo;
   struct winsize ws;
+  bool isOldFirmware = false;
+  
 
   opterr = 0;
-  while ((op = getopt(argc, argv, "t:s:B:a:l:v:V:c:C:T:i:N:n:f:oq")) != -1) {
+  while ((op = getopt(argc, argv, "Ot:s:B:a:l:v:V:c:C:T:i:N:n:f:oq")) != -1) {
     switch(op) {
+	case 'O': isOldFirmware = true; break;
     case 't': ltype = Link::SERIAL; link = optarg; break;
     case 's': ltype = Link::SOCKET; link = optarg; break;
     case 'B': lconf = optarg; break;
@@ -361,6 +365,7 @@ int main(int argc, char *argv[])
   sigaction(SIGINT, &sigact, NULL);
   sigaction(SIGQUIT, &sigact, NULL);
 
+  kp184.setCRCLSBfirst(!isOldFirmware); // new 2020 FW and above have swapped CRC
   rc = kp184.open(ltype, link, lconf);
   if (rc)
     return rc;

--- a/cmdUI/cmdUI.cpp
+++ b/cmdUI/cmdUI.cpp
@@ -232,7 +232,7 @@ static int process_command(int fd, char *line, int len)
 void usage(const char *prog)
 {
   printf("usage: %s <-t tty|-s host[:port]> [-o] [-B conf] [\"cmd 1\"] ...\n", prog);
-  printf(" -o: older KP184 firmware before 2020\n");
+  printf(" -O: older KP184 firmware before 2020\n");
   printf(" -t: communicate via TTY port\n");
   printf(" -s: communicate via socket\n");
   printf(" -B: serial configuration string [%s]\n", getDefaultConfig(Link::SERIAL));
@@ -251,9 +251,9 @@ int main(int argc, char *argv[])
   bool isOldFirmware = false;
 
   opterr = 0;
-  while ((c = getopt(argc, argv, "ot:s:B:")) != -1) {
+  while ((c = getopt(argc, argv, "Ot:s:B:")) != -1) {
     switch(c) {
-    case 'o': isOldFirmware = true; break;
+    case 'O': isOldFirmware = true; break;
     case 't': ltype = Link::SERIAL; link = optarg; break;
     case 's': ltype = Link::SOCKET; link = optarg; break;
     case 'B': lconf = optarg; break;

--- a/cmdUI/cmdUI.cpp
+++ b/cmdUI/cmdUI.cpp
@@ -231,7 +231,8 @@ static int process_command(int fd, char *line, int len)
 
 void usage(const char *prog)
 {
-  printf("usage: %s <-t tty|-s host[:port]> [-B conf] [\"cmd 1\"] ...\n", prog);
+  printf("usage: %s <-t tty|-s host[:port]> [-o] [-B conf] [\"cmd 1\"] ...\n", prog);
+  printf(" -o: older KP184 firmware before 2020\n");
   printf(" -t: communicate via TTY port\n");
   printf(" -s: communicate via socket\n");
   printf(" -B: serial configuration string [%s]\n", getDefaultConfig(Link::SERIAL));
@@ -247,10 +248,12 @@ int main(int argc, char *argv[])
   Link::linktype_t ltype = Link::SERIAL;
   const char *link = NULL, *lconf = NULL, *prog = basename(argv[0]);
   char c;
+  bool isOldFirmware = false;
 
   opterr = 0;
-  while ((c = getopt(argc, argv, "t:s:B:")) != -1) {
+  while ((c = getopt(argc, argv, "ot:s:B:")) != -1) {
     switch(c) {
+    case 'o': isOldFirmware = true; break;
     case 't': ltype = Link::SERIAL; link = optarg; break;
     case 's': ltype = Link::SOCKET; link = optarg; break;
     case 'B': lconf = optarg; break;
@@ -275,7 +278,7 @@ int main(int argc, char *argv[])
   sigaction(SIGINT, &_sigact, NULL);
   sigaction(SIGQUIT, &_sigact, NULL);
 
-  if (openDevice(ltype, link, lconf))
+  if (openDevice(ltype, link, lconf, isOldFirmware))
     return -ENOTCONN;
 
 #ifdef HAVE_READLINE

--- a/cmdUI/dev_KP184.cpp
+++ b/cmdUI/dev_KP184.cpp
@@ -356,8 +356,9 @@ cmd_t devcmds[] = {
   CMD_END
 };
 
-int openDevice(Link::linktype_t type, const char *link, const char *config)
+int openDevice(Link::linktype_t type, const char *link, const char *config, bool isOldFW)
 {
+  kp184.setCRCLSBfirst(!isOldFW); // new 2020 FW and above have swapped CRC
   return kp184.open(type, link, config);
 }
 

--- a/cmdUI/device.h
+++ b/cmdUI/device.h
@@ -12,7 +12,7 @@ typedef struct _cmd_t {
 extern cmd_t devcmds[];
 
 // misc
-int openDevice(Link::linktype_t type, const char link[], const char config[]);
+int openDevice(Link::linktype_t type, const char link[], const char config[], bool isOldFW);
 int reOpenDevice();
 const char *getDefaultConfig(Link::linktype_t type);
 const char *getPrompt();

--- a/include/KP184.h
+++ b/include/KP184.h
@@ -255,14 +255,15 @@ private:
     rc = (int)doIO(sbuf, slen, rbuf, sizeof(rbuf));
     if (rc < 0)
       return rc;
-    if (rc != 7)
+    if (rc < 6)
       return -ENODATA;
     if (rbuf[0] != getAddress())
       return -EFAULT;
     if (rbuf[1] != OP_WRITE1AO)
       return -ENOMSG;
-    if (memcmp(rbuf + 2, sbuf + 2, 4) != 0) // addr + code + reg[2] + val[2]
+    if (memcmp(rbuf + rc - 2, sbuf + slen -2, 2) != 0) { // check only part of rec value. newer fw return shorter answers (6B) ? 
       return -ENODATA;
+  }
 
     return 0;
   }

--- a/include/link.h
+++ b/include/link.h
@@ -43,7 +43,7 @@ public:
     m_fd(-1)
   , m_type(NONE)
   , m_timeout_send({ 2, 0 })
-  , m_timeout_recv({ 0, 50000L }) {
+  , m_timeout_recv({ 0, 1500000L }) {
   }
 
   ~Link() {
@@ -493,6 +493,9 @@ serfail:
 
         if(rc > 0) {
           rlen += rc;
+          // after first rec data, next select timeout can be shorter
+          timeout.tv_sec = 0;
+          timeout.tv_usec = 50000L;
 		}
 
         if (rc < 0) {

--- a/include/link.h
+++ b/include/link.h
@@ -43,7 +43,7 @@ public:
     m_fd(-1)
   , m_type(NONE)
   , m_timeout_send({ 2, 0 })
-  , m_timeout_recv({ 0, 500000L }) {
+  , m_timeout_recv({ 0, 50000L }) {
   }
 
   ~Link() {

--- a/include/mbrtu.h
+++ b/include/mbrtu.h
@@ -198,7 +198,6 @@ protected:
     if (ret < 0)
       return ret;
     if ((size_t)ret == len) {
-      usleep(m_recvdelay);
       if ((ret = recv(rbuf, size)) >= 0) {
 #ifdef MBDEBUG
         if (m_debug)


### PR DESCRIPTION
I added -O switch for older kunkin firmware (before 2020), because there is a different CRC byte order. Also answers from kp184 are also shorter.

Fixed serial receive function, because when select() return, sometimes received data are not completly received yet.